### PR TITLE
Attach key listeners to root element rather than window

### DIFF
--- a/src/ipywwt/static/main.js
+++ b/src/ipywwt/static/main.js
@@ -60007,7 +60007,7 @@ function __extends(e, r) {
   }
   e.prototype = r === null ? Object.create(r) : (n.prototype = r.prototype, new n());
 }
-function __values$1(e) {
+function __values(e) {
   var r = typeof Symbol == "function" && Symbol.iterator, n = r && e[r], s = 0;
   if (n)
     return n.call(e);
@@ -60213,7 +60213,7 @@ function isLayerSetting(e) {
 function extractLayerSettings(e) {
   var r, n, s = [];
   try {
-    for (var a = __values$1(layerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(layerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60232,7 +60232,7 @@ function extractLayerSettings(e) {
 function copyLayerSettings(e, r) {
   var n, s;
   try {
-    for (var a = __values$1(layerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(layerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -60314,7 +60314,7 @@ function isImageSetLayerSetting(e) {
 function extractImageSetLayerSettings(e) {
   var r, n, s = extractLayerSettings(e);
   try {
-    for (var a = __values$1(justImageSetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justImageSetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60334,7 +60334,7 @@ function copyImageSetLayerSettings(e, r) {
   var n, s;
   copyLayerSettings(e, r);
   try {
-    for (var a = __values$1(justImageSetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justImageSetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -60420,7 +60420,7 @@ layerSettingNames.concat(justSpreadSheetLayerSettingNames);
 function extractSpreadSheetLayerSettings(e) {
   var r, n, s = extractLayerSettings(e);
   try {
-    for (var a = __values$1(justSpreadSheetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justSpreadSheetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60440,7 +60440,7 @@ function copySpreadSheetLayerSettings(e, r) {
   var n, s;
   copyLayerSettings(e, r);
   try {
-    for (var a = __values$1(justSpreadSheetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justSpreadSheetLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -60667,7 +60667,7 @@ function isAnnotationSetting(e) {
 function extractAnnotationSettings(e) {
   var r, n, s = [];
   try {
-    for (var a = __values$1(annotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(annotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60686,7 +60686,7 @@ function extractAnnotationSettings(e) {
 function copyAnnotationSettings(e, r) {
   var n, s;
   try {
-    for (var a = __values$1(annotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(annotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -60757,7 +60757,7 @@ function applyCircleAnnotationSetting(e, r) {
 function extractCircleAnnotationSettings(e) {
   var r, n, s = extractAnnotationSettings(e);
   try {
-    for (var a = __values$1(justCircleAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justCircleAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60777,7 +60777,7 @@ function copyCircleAnnotationSettings(e, r) {
   var n, s;
   copyAnnotationSettings(e, r);
   try {
-    for (var a = __values$1(justCircleAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justCircleAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -60848,7 +60848,7 @@ function applyPolyAnnotationSetting(e, r) {
 function extractPolyAnnotationSettings(e) {
   var r, n, s = extractAnnotationSettings(e);
   try {
-    for (var a = __values$1(justPolyAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justPolyAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60868,7 +60868,7 @@ function copyPolyAnnotationSettings(e, r) {
   var n, s;
   copyAnnotationSettings(e, r);
   try {
-    for (var a = __values$1(justPolyAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justPolyAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -60927,7 +60927,7 @@ function applyPolyLineAnnotationSetting(e, r) {
 function extractPolyLineAnnotationSettings(e) {
   var r, n, s = extractAnnotationSettings(e);
   try {
-    for (var a = __values$1(justPolyLineAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justPolyLineAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       s.push([l, e["get_" + l]()]);
     }
@@ -60947,7 +60947,7 @@ function copyPolyLineAnnotationSettings(e, r) {
   var n, s;
   copyAnnotationSettings(e, r);
   try {
-    for (var a = __values$1(justPolyLineAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justPolyLineAnnotationSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -61021,7 +61021,7 @@ function copyVoTableLayerSettings(e, r) {
   var n, s;
   copyLayerSettings(e, r);
   try {
-    for (var a = __values$1(justVoTableLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
+    for (var a = __values(justVoTableLayerSettingNames), t = a.next(); !t.done; t = a.next()) {
       var l = t.value;
       r["set_" + l](e["get_" + l]());
     }
@@ -61393,32 +61393,6 @@ function isModifySelectabilityMessage(e) {
 function isModifyAllSelectabilityMessage(e) {
   return e.type === "modify_all_selectability" && typeof e.selectable == "boolean";
 }
-/*! *****************************************************************************
-Copyright (c) Microsoft Corporation.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
-***************************************************************************** */
-function __values(e) {
-  var r = typeof Symbol == "function" && Symbol.iterator, n = r && e[r], s = 0;
-  if (n)
-    return n.call(e);
-  if (e && typeof e.length == "number")
-    return {
-      next: function() {
-        return e && s >= e.length && (e = void 0), { value: e && e[s++], done: !e };
-      }
-    };
-  throw new TypeError(r ? "Object is not iterable." : "Symbol.iterator is not defined.");
-}
 function isGenericSetting(e) {
   return Object.prototype.toString.call(e) === "[object Array]" && e.length == 2 && typeof e[0] == "string";
 }
@@ -61457,9 +61431,6 @@ function isGetViewAsTourMessage(e) {
 }
 function isPingPongMessage(e) {
   return typeof e.type == "string" && e.type == "wwt_ping_pong" && typeof e.threadId == "string" && (e.sessionId === void 0 || typeof e.sessionId == "string");
-}
-function isClearTileCacheMessage(e) {
-  return typeof e.event == "string" && e.event === "clear_tile_cache";
 }
 const researchAppEngineSettingTypeInfo = {
   "altAzGridColor/string": !0,
@@ -62352,9 +62323,6 @@ const App$1 = /* @__PURE__ */ defineComponent({
       }
       return !1;
     },
-    handleClearTileCache(e) {
-      return isClearTileCacheMessage(e) ? (this.clearTileCache(), !0) : !1;
-    },
     wwtOnPointerMove(e) {
       if (e.buttons == 1) {
         const r = {
@@ -62810,88 +62778,91 @@ const App$1 = /* @__PURE__ */ defineComponent({
           }
         },
         !1
-      );
+      ), this.$nextTick(() => {
+        const r = this.$refs.root;
+        console.log("ROOT"), console.log(r), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener("zoomIn", () => this.doZoom(!0))
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener("zoomOut", () => this.doZoom(!1))
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "moveUp",
+            () => this.doMove(0, this.kcs.moveAmount)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "moveDown",
+            () => this.doMove(0, -this.kcs.moveAmount)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "moveLeft",
+            () => this.doMove(this.kcs.moveAmount, 0)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "moveRight",
+            () => this.doMove(-this.kcs.moveAmount, 0)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "tiltLeft",
+            () => this.doTilt(this.kcs.tiltAmount, 0)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "tiltRight",
+            () => this.doTilt(-this.kcs.tiltAmount, 0)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "tiltUp",
+            () => this.doTilt(0, this.kcs.tiltAmount)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "tiltDown",
+            () => this.doTilt(0, -this.kcs.tiltAmount)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "bigMoveUp",
+            () => this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "bigMoveDown",
+            () => this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "bigMoveLeft",
+            () => this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
+          )
+        ), r.addEventListener(
+          "keydown",
+          this.kcs.makeListener(
+            "bigMoveRight",
+            () => this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
+          )
+        );
+      });
     }), setTimeout(() => {
       this.show = !0;
-    }, 1e3), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener("zoomIn", () => this.doZoom(!0))
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener("zoomOut", () => this.doZoom(!1))
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "moveUp",
-        () => this.doMove(0, this.kcs.moveAmount)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "moveDown",
-        () => this.doMove(0, -this.kcs.moveAmount)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "moveLeft",
-        () => this.doMove(this.kcs.moveAmount, 0)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "moveRight",
-        () => this.doMove(-this.kcs.moveAmount, 0)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "tiltLeft",
-        () => this.doTilt(this.kcs.tiltAmount, 0)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "tiltRight",
-        () => this.doTilt(-this.kcs.tiltAmount, 0)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "tiltUp",
-        () => this.doTilt(0, this.kcs.tiltAmount)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "tiltDown",
-        () => this.doTilt(0, -this.kcs.tiltAmount)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "bigMoveUp",
-        () => this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "bigMoveDown",
-        () => this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "bigMoveLeft",
-        () => this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
-      )
-    ), window.addEventListener(
-      "keydown",
-      this.kcs.makeListener(
-        "bigMoveRight",
-        () => this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
-      )
-    );
+    }, 1e3);
   },
   unmounted() {
     screenfullExports.isEnabled && screenfullExports.off("change", this.onFullscreenEvent), this.updateIntervalId !== null && (window.clearInterval(this.updateIntervalId), this.updateIntervalId = null);
@@ -62948,7 +62919,9 @@ const App$1 = /* @__PURE__ */ defineComponent({
   statusMessageDestination: null
 }), _hoisted_1$3 = {
   key: 0,
-  id: "app"
+  id: "app",
+  ref: "root",
+  tabindex: "0"
 }, _hoisted_2$3 = { id: "ui-elements" }, _hoisted_3$3 = {
   class: "element-box",
   id: "display-panel-box"
@@ -63355,7 +63328,7 @@ function _sfc_render$4(e, r, n, s, a, t) {
     ], 544)), [
       [vShow, e.wwtShowWebGl2Warning]
     ])
-  ])) : createCommentVNode("", !0);
+  ], 512)) : createCommentVNode("", !0);
 }
 const App = /* @__PURE__ */ _export_sfc(App$1, [["render", _sfc_render$4]]), uiColorMaps = [
   { wwt: "viridis", desc: "Viridis" },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -17,7 +17,7 @@
         "@wwtelescope/engine-helpers": "^0.16.0",
         "@wwtelescope/engine-pinia": "^0.9.0",
         "@wwtelescope/engine-types": "^0.6.7",
-        "@wwtelescope/research-app-messages": "https://gitpkg.now.sh/WorldWideTelescope/wwt-webgl-engine/research-app-messages?aa27cedca095517ce022fdf462b519e25418a768&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
+        "@wwtelescope/research-app-messages": "^0.17.3",
         "moment": "^2.29.1",
         "screenfull": "^5",
         "uuid": "^9.0.1",
@@ -2629,11 +2629,9 @@
       }
     },
     "node_modules/@wwtelescope/research-app-messages": {
-      "version": "0.0.0-dev.0",
-      "resolved": "https://gitpkg.now.sh/WorldWideTelescope/wwt-webgl-engine/research-app-messages?aa27cedca095517ce022fdf462b519e25418a768&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
-      "integrity": "sha512-pvypPrNIqVrfRZVsx8ZGheFMT5Kzc85kCMZJrBAci6rVb0zpZ6erMRs9zUWlQkN09ugX5kAdqKwGY0Brf/MtTA==",
-      "hasInstallScript": true,
-      "license": "MIT"
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@wwtelescope/research-app-messages/-/research-app-messages-0.17.3.tgz",
+      "integrity": "sha512-Kv8/xsNnX/UwQauYT0V7e8H3QCKXS5+I47ZfZyRh3jSLmPa9ZzfiAxx28ZtrGtY1NkkW59yVGeFq4JAJkJ4YWg=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",

--- a/src/package.json
+++ b/src/package.json
@@ -18,7 +18,7 @@
     "@wwtelescope/engine-helpers": "^0.16.0",
     "@wwtelescope/engine-pinia": "^0.9.0",
     "@wwtelescope/engine-types": "^0.6.7",
-    "@wwtelescope/research-app-messages": "https://gitpkg.now.sh/WorldWideTelescope/wwt-webgl-engine/research-app-messages?aa27cedca095517ce022fdf462b519e25418a768&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
+    "@wwtelescope/research-app-messages": "^0.17.3",
     "moment": "^2.29.1",
     "screenfull": "^5",
     "uuid": "^9.0.1",

--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -418,7 +418,6 @@ import {
 import {
   classicPywwt,
   isPingPongMessage,
-  isClearTileCacheMessage,
   layers,
   selections,
   settings,
@@ -2032,13 +2031,6 @@ const App = defineComponent({
       return false;
     },
 
-    handleClearTileCache(msg: any): boolean {
-      if (!isClearTileCacheMessage(msg)) return false;
-
-      this.clearTileCache();
-      return true;
-    },
-
     wwtOnPointerMove(event: PointerEvent) {
       // We would like to catch drag operations over wwt. Unfortunately we cannot
       // detect whether the primary button is pressed when the pointer move event
@@ -2939,97 +2931,99 @@ const App = defineComponent({
         },
         false
       );
+
+      this.$nextTick(() => {
+        const root = this.$refs.root as HTMLElement;
+
+        // Handling key presses
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("zoomIn", () => this.doZoom(true))
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("zoomOut", () => this.doZoom(false))
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("moveUp", () =>
+            this.doMove(0, this.kcs.moveAmount)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("moveDown", () =>
+            this.doMove(0, -this.kcs.moveAmount)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("moveLeft", () =>
+            this.doMove(this.kcs.moveAmount, 0)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("moveRight", () =>
+            this.doMove(-this.kcs.moveAmount, 0)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("tiltLeft", () =>
+            this.doTilt(this.kcs.tiltAmount, 0)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("tiltRight", () =>
+            this.doTilt(-this.kcs.tiltAmount, 0)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("tiltUp", () =>
+            this.doTilt(0, this.kcs.tiltAmount)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("tiltDown", () =>
+            this.doTilt(0, -this.kcs.tiltAmount)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("bigMoveUp", () =>
+            this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("bigMoveDown", () =>
+            this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("bigMoveLeft", () =>
+            this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
+          )
+        );
+        root.addEventListener(
+          "keydown",
+          this.kcs.makeListener("bigMoveRight", () =>
+            this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
+          )
+        ); 
+      });
+
     });
 
     setTimeout(() => {
       this.show = true;
     }, 1000);
 
-    const root = this.$refs.root as HTMLElement;
-    console.log("ROOT");
-    console.log(root);
-
-    // Handling key presses
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("zoomIn", () => this.doZoom(true))
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("zoomOut", () => this.doZoom(false))
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("moveUp", () =>
-        this.doMove(0, this.kcs.moveAmount)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("moveDown", () =>
-        this.doMove(0, -this.kcs.moveAmount)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("moveLeft", () =>
-        this.doMove(this.kcs.moveAmount, 0)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("moveRight", () =>
-        this.doMove(-this.kcs.moveAmount, 0)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("tiltLeft", () =>
-        this.doTilt(this.kcs.tiltAmount, 0)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("tiltRight", () =>
-        this.doTilt(-this.kcs.tiltAmount, 0)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("tiltUp", () =>
-        this.doTilt(0, this.kcs.tiltAmount)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("tiltDown", () =>
-        this.doTilt(0, -this.kcs.tiltAmount)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("bigMoveUp", () =>
-        this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("bigMoveDown", () =>
-        this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("bigMoveLeft", () =>
-        this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
-      )
-    );
-    root.addEventListener(
-      "keydown",
-      this.kcs.makeListener("bigMoveRight", () =>
-        this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
-      )
-    );
   },
 
   unmounted() {

--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -1,6 +1,9 @@
 <template>
-  <div id="app"
-      v-if="show">
+  <div
+      id="app"
+      v-if="show"
+      ref="root"
+      tabindex="0">
     <WorldWideTelescope
       :wwt-namespace="wwtComponentNamespace"
       :class="['wwt', { pointer: lastClosePt !== null }]"
@@ -2942,82 +2945,86 @@ const App = defineComponent({
       this.show = true;
     }, 1000);
 
+    const root = this.$refs.root as HTMLElement;
+    console.log("ROOT");
+    console.log(root);
+
     // Handling key presses
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("zoomIn", () => this.doZoom(true))
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("zoomOut", () => this.doZoom(false))
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("moveUp", () =>
         this.doMove(0, this.kcs.moveAmount)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("moveDown", () =>
         this.doMove(0, -this.kcs.moveAmount)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("moveLeft", () =>
         this.doMove(this.kcs.moveAmount, 0)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("moveRight", () =>
         this.doMove(-this.kcs.moveAmount, 0)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("tiltLeft", () =>
         this.doTilt(this.kcs.tiltAmount, 0)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("tiltRight", () =>
         this.doTilt(-this.kcs.tiltAmount, 0)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("tiltUp", () =>
         this.doTilt(0, this.kcs.tiltAmount)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("tiltDown", () =>
         this.doTilt(0, -this.kcs.tiltAmount)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("bigMoveUp", () =>
         this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("bigMoveDown", () =>
         this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("bigMoveLeft", () =>
         this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
       )
     );
-    window.addEventListener(
+    root.addEventListener(
       "keydown",
       this.kcs.makeListener("bigMoveRight", () =>
         this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)

--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -2932,91 +2932,89 @@ const App = defineComponent({
         false
       );
 
-      this.$nextTick(() => {
-        const root = this.$refs.root as HTMLElement;
+      const root = this.$refs.root as HTMLElement;
 
-        // Handling key presses
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("zoomIn", () => this.doZoom(true))
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("zoomOut", () => this.doZoom(false))
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("moveUp", () =>
-            this.doMove(0, this.kcs.moveAmount)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("moveDown", () =>
-            this.doMove(0, -this.kcs.moveAmount)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("moveLeft", () =>
-            this.doMove(this.kcs.moveAmount, 0)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("moveRight", () =>
-            this.doMove(-this.kcs.moveAmount, 0)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("tiltLeft", () =>
-            this.doTilt(this.kcs.tiltAmount, 0)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("tiltRight", () =>
-            this.doTilt(-this.kcs.tiltAmount, 0)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("tiltUp", () =>
-            this.doTilt(0, this.kcs.tiltAmount)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("tiltDown", () =>
-            this.doTilt(0, -this.kcs.tiltAmount)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("bigMoveUp", () =>
-            this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("bigMoveDown", () =>
-            this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("bigMoveLeft", () =>
-            this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
-          )
-        );
-        root.addEventListener(
-          "keydown",
-          this.kcs.makeListener("bigMoveRight", () =>
-            this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
-          )
-        ); 
-      });
+      // Handling key presses
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("zoomIn", () => this.doZoom(true))
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("zoomOut", () => this.doZoom(false))
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("moveUp", () =>
+          this.doMove(0, this.kcs.moveAmount)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("moveDown", () =>
+          this.doMove(0, -this.kcs.moveAmount)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("moveLeft", () =>
+          this.doMove(this.kcs.moveAmount, 0)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("moveRight", () =>
+          this.doMove(-this.kcs.moveAmount, 0)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("tiltLeft", () =>
+          this.doTilt(this.kcs.tiltAmount, 0)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("tiltRight", () =>
+          this.doTilt(-this.kcs.tiltAmount, 0)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("tiltUp", () =>
+          this.doTilt(0, this.kcs.tiltAmount)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("tiltDown", () =>
+          this.doTilt(0, -this.kcs.tiltAmount)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("bigMoveUp", () =>
+          this.doMove(0, this.kcs.bigMoveFactor * this.kcs.moveAmount)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("bigMoveDown", () =>
+          this.doMove(0, this.kcs.bigMoveFactor * -this.kcs.moveAmount)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("bigMoveLeft", () =>
+          this.doMove(this.kcs.bigMoveFactor * this.kcs.moveAmount, 0)
+        )
+      );
+      root.addEventListener(
+        "keydown",
+        this.kcs.makeListener("bigMoveRight", () =>
+          this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
+        )
+      ); 
 
     });
 


### PR DESCRIPTION
This PR provides a workaround for the keypress-handling issue that we were seeing by attaching the handlers to the component root rather than the window.

@nmearl I couldn't get this to build using the `gitpkg` URL for `research-app-messages` (I was getting an error from rollup), so I just reverted to the latest release and removed the cache-clearing handler from the component. Feel free to undo those changes if you want.