### PR TITLE
Queue messages

### DIFF
--- a/notebooks/Example.ipynb
+++ b/notebooks/Example.ipynb
@@ -2,191 +2,93 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "18c83c16-1d34-4896-80db-4033ca98dc83",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ipywwt import WWTWidget"
+    "from ipywwt import WWTWidget\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import astropy.units as u\n",
+    "from time import sleep"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "dfe314ae-6486-449c-aa73-cdf1b54db29c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4fcd34da671343fa87ed3f3bf2fe535b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(WWTWidget(), Output()))"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
    "source": [
     "import ipywidgets\n",
     "\n",
     "output = ipywidgets.Output()\n",
     "\n",
-    "# @output.capture()\n",
-    "# def on_msg(_widget, msg, buffers):\n",
-    "#     print(f'Received: {type(msg)}')\n",
+    "@output.capture()\n",
+    "def on_msg(_widget, msg, buffers):\n",
+    "    pretty_msg = msg\n",
+    "    for k,v in msg.items():\n",
+    "        if isinstance(v, list):\n",
+    "            pretty_msg[k] = v[:2]\n",
+    "        elif isinstance(v,str) and (len(v) > 80):\n",
+    "            pretty_msg[k] = v[:80]\n",
+    "    print(f'Received: {(pretty_msg)}')\n",
     "\n",
     "@output.capture()\n",
     "def wwt_cb(wwt, updated):\n",
     "    print(updated)\n",
     "\n",
+    "@output.capture()\n",
+    "def ready():\n",
+    "    print('ready')\n",
+    "\n",
     "wwt1 = WWTWidget()\n",
     "\n",
-    "# wwt1.on_msg(on_msg)\n",
+    "\n",
+    "# Setup the view\n",
+    "wwt1.background = \"USNOB: US Naval Observatory B 1.0 (Synthetic, Optical)\"\n",
+    "wwt1.foreground = \"SDSS: Sloan Digital Sky Survey (Optical)\"\n",
+    "wwt1.center_on_coordinates(SkyCoord(285.0130833333333 * u.deg,40.22075 * u.deg), instant=True)\n",
+    "\n",
+    "\n",
+    "def add_layer():\n",
+    "    \"\"\"\n",
+    "    layers will only be added after the app is mounted. \n",
+    "    They also seem to need a bit more time, otherwise sometimes\n",
+    "        it will not show up.\n",
+    "    \"\"\"\n",
+    "    sleep(.1)\n",
+    "    OEC = '/Applications/John/github/minids/radwave/src/assets/radwave/RW_cluster_oscillation_0_updated_radec.csv'\n",
+    "\n",
+    "    table = Table.read(OEC, delimiter=',', format='ascii.basic')\n",
+    "\n",
+    "    layer = wwt1.layers.add_table_layer(table=table, frame='Sky',\n",
+    "                               lon_att='ra', lat_att='dec')\n",
+    "    layer.size_scale = 200\n",
+    "    layer.type = \"gaussian\"\n",
+    "    layer.color = \"#00FF00\"\n",
+    "    \n",
+    "    \n",
+    "\n",
+    "\n",
+    "# on ready is the first thing run after queued messages\n",
+    "wwt1.on_ready(ready)\n",
+    "\n",
+    "# then callbacks added after are run in order. These Callbacks take no parameters. \n",
+    "wwt1.ensure_mounted(add_layer)\n",
+    "# wwt1.ensure_mounted(style_layer)\n",
+    "\n",
+    "\n",
+    "wwt1.on_msg(on_msg)\n",
     "wwt1.set_selection_change_callback(wwt_cb)\n",
     "\n",
     "# wwt1.on_msg(lambda w, m, b: wwt1._on_app_message_received(m, b))\n",
     "    \n",
     "\n",
     "ipywidgets.VBox([wwt1, output])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "824eab7a-4120-49cc-bf06-f8e28b1d6373",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<TableLayer with 89 markers>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from astropy.table import Table\n",
-    "OEC = '/Users/nmearl/Downloads/RW_cluster_oscillation_0_updated_radec.csv'\n",
-    "table = Table.read(OEC, delimiter=',', format='ascii.basic')\n",
-    "\n",
-    "wwt1.layers.add_table_layer(table=table, frame='Sky',\n",
-    "                           lon_att='ra', lat_att='dec')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "83a11c14-1eb7-421c-9899-775734dcc560",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wwt1.layers[0].size_scale = 100\n",
-    "wwt1.layers[0].type = \"gaussian\"\n",
-    "wwt1.layers[0].color = \"#00FF00\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "a0616558-9e2f-4d1b-8c2d-8847256ddb9f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$28.697814 \\; \\mathrm{{}^{\\circ}}$"
-      ],
-      "text/plain": [
-       "<Quantity 28.69781401 deg>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "wwt1.get_fov()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "27e74544-09b1-483f-b905-8b0d091e0a16",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a46ad6dfc9f94916a2a70d57df13ce00",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Layout()"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9b35f180-1d5e-4997-a02f-410ab621efa9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.coordinates import SkyCoord\n",
-    "import astropy.units as u\n",
-    "# wwt1.center_on_coordinates(SkyCoord.from_name('Andromeda'), instant=True)\n",
-    "wwt1.center_on_coordinates(SkyCoord(285.0130833333333 * u.deg,40.22075 * u.deg), instant=True)\n",
-    "# wwt1.center_on_coordinates(SkyCoord(180 * u.deg, 25 * u.deg, frame='icrs'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c539e8eb-4b98-4051-8ee5-5696cf0ea948",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# wwt1.background = \"WMAP ILC 5-Year Cosmic Microwave Background\"\n",
-    "wwt1.background = \"SDSS: Sloan Digital Sky Survey (Optical)\"\n",
-    "wwt1.foreground = \"SDSS: Sloan Digital Sky Survey (Optical)\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "96d8b6f3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wwt2 = WWTWidget()\n",
-    "wwt2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "80d8e319-508a-4291-a246-0099d0ae9bf8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wwt1.layers[0].id"
    ]
   },
   {
@@ -214,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/src/ipywwt/static/main.js
+++ b/src/ipywwt/static/main.js
@@ -62166,7 +62166,7 @@ const App$1 = /* @__PURE__ */ defineComponent({
       lastClosePt: null,
       lastSelectedSource: null,
       selectionProximity: 4,
-      hideAllChrome: !1,
+      hideAllChrome: !0,
       hipsUrl: `${window.location.protocol}//www.worldwidetelescope.org/wwtweb/catalog.aspx?W=hips`,
       // Temporary
       isPointerMoving: !1,
@@ -62285,6 +62285,11 @@ const App$1 = /* @__PURE__ */ defineComponent({
       "removeResearchAppTableLayer",
       "setResearchAppTableLayerSelectability"
     ]),
+    onMounted() {
+      const e = setInterval(() => {
+        this.show && (console.log("Research app mounted"), window.postMessage({ event: "research_app_ready" }, "*"), clearInterval(e));
+      }, 100);
+    },
     parseFloatParam(e, r) {
       return typeof e == "string" && parseFloat(e) || r;
     },
@@ -63187,6 +63192,8 @@ const App$1 = /* @__PURE__ */ defineComponent({
           () => this.doMove(this.kcs.bigMoveFactor * -this.kcs.moveAmount, 0)
         )
       );
+    }).then(() => {
+      this.onMounted();
     }), setTimeout(() => {
       this.show = !0;
     }, 1e3);
@@ -64459,7 +64466,7 @@ const TransitionExpand = /* @__PURE__ */ _export_sfc(_sfc_main, [["render", _sfc
 function createRender(e) {
   return ({ model: r, el: n }) => {
     let s = document.createElement("div");
-    s.setAttribute("id", "app-wrapper"), s.style.setProperty("height", "400px", ""), s.style.setProperty("width", "100%", ""), s.style.setProperty("border", "none", ""), n.appendChild(s);
+    s.setAttribute("id", "app-wrapper"), s.style.setProperty("height", "400px", ""), s.style.setProperty("width", "100%", ""), s.style.setProperty("border", "none", ""), r.get("mounted"), n.appendChild(s);
     let a = e.mount(s);
     return window.vm = a, a.layers = {}, r.on("msg:custom", (t) => {
       let l = null, o = null, c = null;
@@ -64468,7 +64475,7 @@ function createRender(e) {
           console.log(isCenterOnCoordinatesMessage(t)), window.postMessage(t);
           break;
         case "table_layer_create":
-          window.postMessage(t);
+          console.log("table_layer_create", t), window.postMessage(t);
           break;
         case "table_layer_update":
           window.postMessage(t);
@@ -64499,6 +64506,10 @@ function createRender(e) {
     }), window.addEventListener(
       "message",
       (t) => {
+        if (t.data.event === "research_app_ready") {
+          console.log("Research app ready"), r.set("mounted", !0), r.save_changes();
+          return;
+        }
         r.send(t.data);
       },
       !1

--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -1369,6 +1369,18 @@ const App = defineComponent({
       'setResearchAppTableLayerSelectability',
     ]),
 
+    onMounted() {
+      // wait for show to be true
+      const interval = setInterval(() => {
+        if (this.show) {
+          console.log("Research app mounted");
+          window.postMessage({ event: "research_app_ready" }, "*");
+          clearInterval(interval);
+        }
+      }, 100);
+      
+    },
+
     parseFloatParam(param: string | (string | null)[], fallback: number): number {
       if (typeof param === "string") {
         const value = parseFloat(param);
@@ -3016,7 +3028,11 @@ const App = defineComponent({
         )
       ); 
 
-    });
+    }).then(() => {
+      // We need to wait for the engine to be ready before we can start
+      // listening for messages.
+      this.onMounted();
+    })
 
     setTimeout(() => {
       this.show = true;

--- a/src/src/createRender.js
+++ b/src/src/createRender.js
@@ -44,6 +44,8 @@ export function createRender(app) {
         div.style.setProperty('border', 'none', '');
 
         // iframe.contentWindow.document.body.appendChild(div);
+        
+        let mounted = model.get("mounted");
 
         el.appendChild(div);
 
@@ -66,6 +68,7 @@ export function createRender(app) {
                     window.postMessage(msg);
                     break;
                 case "table_layer_create":
+                    console.log('table_layer_create',msg);
                     window.postMessage(msg);
                     break;
                 case "table_layer_update":
@@ -141,6 +144,12 @@ export function createRender(app) {
         window.addEventListener(
             "message",
             (event) => {
+                if (event.data.event === "research_app_ready") {
+                    console.log("Research app ready");
+                    model.set("mounted", true);
+                    model.save_changes();
+                    return ;
+                }
                 model.send(event.data);
             }, false);
 


### PR DESCRIPTION
So this implements a queue allowing certain messages to be stored until the app is loaded. This works pretty well for foreground/background, but for tables is not very stable. Tables need the app to be fully ready. They seem to need an additional bit of time after the app is mounted in order to stably load and be interacted with. Adding 0.1 sec before loading tables seems to fix this. 

This adds a `onMounted()` callback to the vue app, and a `mounted` traitlet which is synced to the front-end (`.tag(sync=True)`). This is more reliable than attempting to pass a message from the the front-end to the backend. There are two ways to add functions to run when mounted. `on_ready(callback)` and `ensure_mounted(callback)`. `on_ready` adds what is passed to a list of callbacks which get run in order when mounted. `ensure_mounted` either runs the callback immediately if the app is mounted, or it will add it to the `on_ready` stack. The app will run stored messasges, then the callbacks when mounted. 